### PR TITLE
Update variable option label for parent items in tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.8.0 (IN PROGRESS)
+
+### Features / Enhancements
+
+- Update variable option label for parent items in tree view (#62)
+
 ## 1.7.0 (2023-08-08)
 
 ### Features / Enhancements

--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },
-  "version": "1.7.0"
+  "version": "1.8.0"
 }

--- a/src/hooks/useTable.test.tsx
+++ b/src/hooks/useTable.test.tsx
@@ -180,7 +180,7 @@ describe('Use Table Hook', () => {
   });
 
   it('Should return rows with subRows if nested levels', () => {
-    const variable = {
+    const deviceVariable = {
       multi: true,
       includeAll: true,
       type: VariableType.CUSTOM,
@@ -202,18 +202,35 @@ describe('Use Table Hook', () => {
         },
       ],
     };
+    const countryVariable = {
+      multi: true,
+      name: 'country',
+      type: VariableType.CUSTOM,
+      options: [
+        {
+          text: 'USA',
+          value: 'country1',
+          selected: false,
+        },
+        {
+          text: 'Japan',
+          value: 'country2',
+          selected: false,
+        },
+      ],
+    };
     jest.mocked(useRuntimeVariables).mockImplementation(
       () =>
         ({
-          variable,
-          getVariable: jest.fn(() => variable),
+          variable: deviceVariable,
+          getVariable: jest.fn((name: string) => (name === 'country' ? countryVariable : deviceVariable)),
         } as any)
     );
     const dataFrame = toDataFrame({
       fields: [
         {
           name: 'country',
-          values: ['USA', 'Japan'],
+          values: ['country1', 'country2'],
         },
         {
           name: 'device',
@@ -240,7 +257,8 @@ describe('Use Table Hook', () => {
 
     expect(result.current.tableData).toEqual([
       expect.objectContaining({
-        value: 'USA',
+        value: 'country1',
+        label: 'USA',
         selected: false,
         selectable: false,
         childValues: ['device1'],
@@ -252,7 +270,8 @@ describe('Use Table Hook', () => {
         ],
       }),
       expect.objectContaining({
-        value: 'Japan',
+        value: 'country2',
+        label: 'Japan',
         selected: false,
         selectable: false,
         childValues: ['device2'],

--- a/src/hooks/useTable.tsx
+++ b/src/hooks/useTable.tsx
@@ -77,9 +77,14 @@ export const useTable = ({
        * Use Group levels
        */
       const rows = getRows(data, groupFields, (item, key, children) => {
-        const value = item[key as keyof typeof item];
+        /**
+         * Convert value to string
+         */
+        const value = `${item[key as keyof typeof item]}`;
         const levelVariable = getRuntimeVariable(key);
-        const variableOption = runtimeVariable.options.find((option) => option.value === value);
+        const variableOption = isVariableWithOptions(levelVariable)
+          ? levelVariable.options.find((option) => option.value === value)
+          : runtimeVariable.options.find((option) => option.value === value);
 
         return getItemWithStatus(
           {


### PR DESCRIPTION
Resolves #61 

Assumption: variable option value is always string