### PR TITLE
Add an option for always visible search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.1.0 (IN PROGRESS)
+
+### Features / Enhancements
+
+- Add an option for always visible search filter (#83)
+
 ## 2.0.0 (2023-10-16)
 
 ### Features / Enhancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volkovlabs-variable-panel",
-  "version": "1.8.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volkovlabs-variable-panel",
-      "version": "1.8.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",

--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "test:ci": "jest --maxWorkers 4 --coverage",
     "upgrade": "npm upgrade --save"
   },
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/src/components/Table/Filter.tsx
+++ b/src/components/Table/Filter.tsx
@@ -12,13 +12,18 @@ interface Props<TableData extends object> {
    * Column
    */
   column: Column<TableData, unknown>;
+
+  /**
+   * Always Visible
+   */
+  alwaysVisible: boolean;
 }
 
 /**
  * Filter
  * @param props
  */
-export const Filter = <TableData extends object>({ column }: Props<TableData>) => {
+export const Filter = <TableData extends object>({ column, alwaysVisible }: Props<TableData>) => {
   /**
    * Styles
    */
@@ -27,7 +32,7 @@ export const Filter = <TableData extends object>({ column }: Props<TableData>) =
   /**
    * States
    */
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(alwaysVisible);
 
   /**
    * Current filter value
@@ -70,6 +75,20 @@ export const Filter = <TableData extends object>({ column }: Props<TableData>) =
     );
   }
 
+  const search = (
+    <Input
+      placeholder="Search values"
+      value={typeof columnFilterValue === 'string' ? columnFilterValue : ''}
+      onChange={onChangeFilterValue}
+      className={styles.filterInput}
+      data-testid={TestIds.table.fieldFilterValue}
+    />
+  );
+
+  if (alwaysVisible) {
+    return search;
+  }
+
   /**
    * Render filter for other columns
    */
@@ -83,15 +102,7 @@ export const Filter = <TableData extends object>({ column }: Props<TableData>) =
         className={styles.headerButton}
         data-testid={TestIds.table.buttonFilter}
       />
-      {isOpen && (
-        <Input
-          placeholder="Search values"
-          value={typeof columnFilterValue === 'string' ? columnFilterValue : ''}
-          onChange={onChangeFilterValue}
-          className={styles.filterInput}
-          data-testid={TestIds.table.fieldFilterValue}
-        />
-      )}
+      {isOpen && search}
     </>
   );
 };

--- a/src/components/Table/Filter.tsx
+++ b/src/components/Table/Filter.tsx
@@ -75,6 +75,9 @@ export const Filter = <TableData extends object>({ column, alwaysVisible }: Prop
     );
   }
 
+  /**
+   * Search
+   */
   const search = (
     <Input
       placeholder="Search values"
@@ -85,6 +88,9 @@ export const Filter = <TableData extends object>({ column, alwaysVisible }: Prop
     />
   );
 
+  /**
+   * Always visible enabled
+   */
   if (alwaysVisible) {
     return search;
   }

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -6,6 +6,11 @@ import { TestIds } from '../../constants';
 import { Table } from './Table';
 
 /**
+ * Props
+ */
+type Props = React.ComponentProps<typeof Table>;
+
+/**
  * Test Ids only for tests
  */
 const InTestIds = {
@@ -32,7 +37,7 @@ describe('Table', () => {
    * Get Tested Component
    * @param props
    */
-  const getComponent = (props: any) => <Wrapper {...props} />;
+  const getComponent = (props: Partial<Props>) => <Wrapper {...props} />;
 
   /**
    * Selectors
@@ -78,7 +83,7 @@ describe('Table', () => {
       },
     ];
 
-    render(getComponent({ data, columns, getSubRows: (row: any) => row.children }));
+    render(getComponent({ data, columns: columns as any, getSubRows: (row: any) => row.children }));
 
     /**
      * Check first row with sub rows
@@ -150,6 +155,33 @@ describe('Table', () => {
 
     expect(selectors.cell(false, 'device1', 0)).toBeInTheDocument();
     expect(selectors.cell(true, 'device2', 0)).not.toBeInTheDocument();
+  });
+
+  it('Should always show value filter', async () => {
+    render(
+      getComponent({
+        showHeader: true,
+        columns: [
+          {
+            id: 'value',
+            header: 'cell header',
+            accessorKey: 'value',
+            enableColumnFilter: true,
+            cell: ({ getValue, row }: any) => {
+              const value = getValue() as string;
+              return <span data-testid={InTestIds.cell(value, row.depth)}>{value}</span>;
+            },
+          },
+        ],
+        data: [{ value: 'device1' }, { value: 'device2' }],
+        alwaysVisibleFilter: true,
+      })
+    );
+
+    /**
+     * Check Filter Content Presence
+     */
+    expect(selectors.fieldFilterValue()).toBeInTheDocument();
   });
 
   it('Should show value sorting', async () => {

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { ColumnDef } from '@tanstack/react-table';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import { getJestSelectors } from '@volkovlabs/jest-selectors';
 import { TestIds } from '../../constants';
 import { Table } from './Table';
 
@@ -8,8 +9,8 @@ import { Table } from './Table';
  * Test Ids only for tests
  */
 const InTestIds = {
-  cell: (value: string, depth: number) => `cell-${depth}-${value},`,
-  favoriteCell: (value: string, depth: number) => `cell-favorite-${depth}-${value}`,
+  cell: (value: string, depth: number) => `data-testid cell-${depth}-${value},`,
+  favoriteCell: (value: string, depth: number) => `data-testid cell-favorite-${depth}-${value}`,
 };
 
 describe('Table', () => {
@@ -32,6 +33,15 @@ describe('Table', () => {
    * @param props
    */
   const getComponent = (props: any) => <Wrapper {...props} />;
+
+  /**
+   * Selectors
+   */
+  const getSelectors = getJestSelectors({
+    ...TestIds.table,
+    ...InTestIds,
+  });
+  const selectors = getSelectors(screen);
 
   it('Should render all levels', () => {
     const data = [
@@ -73,28 +83,28 @@ describe('Table', () => {
     /**
      * Check first row with sub rows
      */
-    expect(screen.getByTestId(InTestIds.cell('1', 0))).toBeInTheDocument();
-    expect(screen.getByTestId(InTestIds.cell('1-1', 1))).toBeInTheDocument();
-    expect(screen.getByTestId(InTestIds.cell('1-2', 1))).toBeInTheDocument();
+    expect(selectors.cell(false, '1', 0)).toBeInTheDocument();
+    expect(selectors.cell(false, '1-1', 1)).toBeInTheDocument();
+    expect(selectors.cell(false, '1-2', 1)).toBeInTheDocument();
 
     /**
      * Check second row with sub rows
      */
-    expect(screen.getByTestId(InTestIds.cell('2', 0))).toBeInTheDocument();
-    expect(screen.getByTestId(InTestIds.cell('2-1', 1))).toBeInTheDocument();
-    expect(screen.getByTestId(InTestIds.cell('2-2', 1))).toBeInTheDocument();
+    expect(selectors.cell(false, '2', 0)).toBeInTheDocument();
+    expect(selectors.cell(false, '2-1', 1)).toBeInTheDocument();
+    expect(selectors.cell(false, '2-2', 1)).toBeInTheDocument();
   });
 
   it('Should render header', () => {
     render(getComponent({ showHeader: true, columns: [{ id: 'value', header: 'cell header' }], data: [] }));
 
-    expect(screen.getByTestId(TestIds.table.header)).toBeInTheDocument();
+    expect(selectors.header()).toBeInTheDocument();
   });
 
   it('Should not render header', () => {
     render(getComponent({ showHeader: false, columns: [{ id: 'value', header: 'cell header' }], data: [] }));
 
-    expect(screen.queryByTestId(TestIds.table.header)).not.toBeInTheDocument();
+    expect(selectors.header(true)).not.toBeInTheDocument();
   });
 
   it('Should show value filter', async () => {
@@ -120,28 +130,26 @@ describe('Table', () => {
     /**
      * Check Filter presence
      */
-    expect(screen.getByTestId(TestIds.table.buttonFilter)).toBeInTheDocument();
-    expect(screen.queryByTestId(TestIds.table.fieldFilterValue)).not.toBeInTheDocument();
+    expect(selectors.buttonFilter()).toBeInTheDocument();
+    expect(selectors.fieldFilterValue(true)).not.toBeInTheDocument();
 
     /**
      * Open Filter
      */
-    fireEvent.click(screen.getByTestId(TestIds.table.buttonFilter));
+    fireEvent.click(selectors.buttonFilter());
 
     /**
      * Check Filter Content Presence
      */
-    expect(screen.getByTestId(TestIds.table.fieldFilterValue)).toBeInTheDocument();
+    expect(selectors.fieldFilterValue()).toBeInTheDocument();
 
     /**
      * Apply filter
      */
-    await act(() =>
-      fireEvent.change(screen.getByTestId(TestIds.table.fieldFilterValue), { target: { value: 'device1' } })
-    );
+    await act(() => fireEvent.change(selectors.fieldFilterValue(), { target: { value: 'device1' } }));
 
-    expect(screen.getByTestId(InTestIds.cell('device1', 0))).toBeInTheDocument();
-    expect(screen.queryByTestId(InTestIds.cell('device2', 0))).not.toBeInTheDocument();
+    expect(selectors.cell(false, 'device1', 0)).toBeInTheDocument();
+    expect(selectors.cell(true, 'device2', 0)).not.toBeInTheDocument();
   });
 
   it('Should show value sorting', async () => {
@@ -171,12 +179,12 @@ describe('Table', () => {
     /**
      * Check Sort presence
      */
-    expect(screen.getByTestId(TestIds.table.buttonSort)).toBeInTheDocument();
+    expect(selectors.buttonSort()).toBeInTheDocument();
 
     /**
      * Apply asc sorting
      */
-    await act(async () => fireEvent.click(screen.getByTestId(TestIds.table.buttonSort)));
+    await act(async () => fireEvent.click(selectors.buttonSort()));
 
     /**
      * Check Asc Sort order
@@ -188,7 +196,7 @@ describe('Table', () => {
     /**
      * Apply desc sorting
      */
-    await act(async () => fireEvent.click(screen.getByTestId(TestIds.table.buttonSort)));
+    await act(async () => fireEvent.click(selectors.buttonSort()));
 
     /**
      * Check Desc Sort order
@@ -234,15 +242,15 @@ describe('Table', () => {
     /**
      * Check Filter presence
      */
-    expect(screen.getByTestId(TestIds.table.favoritesFilter)).toBeInTheDocument();
+    expect(selectors.favoritesFilter()).toBeInTheDocument();
 
     /**
      * Apply Favorite filter
      */
     await act(() => fireEvent.click(screen.getByTestId(TestIds.table.favoritesFilter)));
 
-    expect(screen.getByTestId(InTestIds.cell('device1', 0))).toBeInTheDocument();
-    expect(screen.queryByTestId(InTestIds.cell('device2', 0))).not.toBeInTheDocument();
+    expect(selectors.cell(false, 'device1', 0)).toBeInTheDocument();
+    expect(selectors.cell(true, 'device2', 0)).not.toBeInTheDocument();
   });
 
   it('Should not show filter', () => {
@@ -254,6 +262,6 @@ describe('Table', () => {
       })
     );
 
-    expect(screen.queryByTestId(TestIds.table.buttonFilter)).not.toBeInTheDocument();
+    expect(selectors.buttonFilter(true)).not.toBeInTheDocument();
   });
 });

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -71,6 +71,11 @@ interface Props<TableData extends object> {
    * Scrollable Container Ref
    */
   scrollableContainerRef: RefObject<HTMLDivElement>;
+
+  /**
+   * Always Visible Filter
+   */
+  alwaysVisibleFilter: boolean;
 }
 
 /**
@@ -88,6 +93,7 @@ export const Table = <TableData extends object>({
   topOffset = 0,
   tableHeaderRef,
   scrollableContainerRef,
+  alwaysVisibleFilter,
 }: Props<TableData>) => {
   /**
    * Styles
@@ -197,7 +203,9 @@ export const Table = <TableData extends object>({
                           title="Sort by status"
                         />
                       )}
-                      {header.column.getCanFilter() && <Filter column={header.column} />}
+                      {header.column.getCanFilter() && (
+                        <Filter column={header.column} alwaysVisible={alwaysVisibleFilter} />
+                      )}
                     </th>
                   );
                 })}

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -169,6 +169,7 @@ export const TableView: React.FC<Props> = ({ data, options, width, height, event
             tableHeaderRef={tableHeaderRef}
             topOffset={tableTopOffset}
             scrollableContainerRef={scrollableContainerRef}
+            alwaysVisibleFilter={options.alwaysVisibleFilter}
           />
         </div>
       </div>

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -4,9 +4,9 @@ import { PanelProps } from '@grafana/data';
 import { Alert, ClickOutsideWrapper, Tab, TabsBar, useTheme2 } from '@grafana/ui';
 import { TestIds } from '../../constants';
 import { useContentPosition, useContentSizes, useScrollTo, useTable } from '../../hooks';
-import { Styles } from './styles';
 import { PanelOptions } from '../../types';
 import { Table } from '../Table';
+import { Styles } from './styles';
 
 /**
  * Properties

--- a/src/constants/panel.ts
+++ b/src/constants/panel.ts
@@ -34,6 +34,14 @@ export const FilterOptions = [
 ];
 
 /**
+ * Always Visible Filter
+ */
+export const AlwaysVisibleFilterOptions = [
+  { value: true, label: 'Enabled', description: 'Always Visible Search.' },
+  { value: false, label: 'Disabled', description: 'Toggleable Search Visibility.' },
+];
+
+/**
  * Favorites Options
  */
 export const FavoritesOptions = [

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { GroupsEditor, VariablePanel } from './components';
 import {
   AllowEmptyValueOptions,
+  AlwaysVisibleFilterOptions,
   AutoScrollOptions,
   DisplayModeOptions,
   FavoritesOptions,
@@ -131,6 +132,16 @@ export const plugin = new PanelPlugin<PanelOptions>(VariablePanel)
         defaultValue: false,
         category: ['Header'],
         showIf: (config) => showForTableView(config) && config.header,
+      })
+      .addRadio({
+        path: 'alwaysVisibleFilter',
+        name: 'Always Visible Search',
+        settings: {
+          options: AlwaysVisibleFilterOptions,
+        },
+        defaultValue: false,
+        category: ['Header'],
+        showIf: (config) => showForTableView(config) && config.header && config.filter,
       })
       .addRadio({
         path: 'favorites',

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -83,6 +83,11 @@ export interface TableViewOptions {
   filter: boolean;
 
   /**
+   * Always Visible Filter
+   */
+  alwaysVisibleFilter: boolean;
+
+  /**
    * Select Favorites
    */
   favorites: boolean;


### PR DESCRIPTION
Resolves #82 

Option makes search field is always visible and hides filter button
<img width="335" alt="Screenshot 2023-11-07 at 08 44 04" src="https://github.com/VolkovLabs/volkovlabs-variable-panel/assets/15867703/cb97f1f2-1561-4903-9e0b-817c52e7b20b">
