### PR TITLE
Add selecting fields from data frames without RefId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Features / Enhancements
 
-- Add an option for an always visible search filter (#83)
+- Add an option for an always-visible search filter (#83)
 - Add Group rename functionality (#84)
+- Add selecting fields from data frames without RefId (#85)
 
 ## 2.0.0 (2023-10-16)
 

--- a/src/components/LevelsEditor/LevelsEditor.test.tsx
+++ b/src/components/LevelsEditor/LevelsEditor.test.tsx
@@ -90,6 +90,10 @@ describe('LevelsEditor', () => {
     refId: 'B',
   });
 
+  beforeEach(() => {
+    jest.mocked(Select).mockClear();
+  });
+
   it('Should render levels', () => {
     render(
       getComponent({
@@ -152,6 +156,56 @@ describe('LevelsEditor', () => {
     );
   });
 
+  it('Should allow select any fields from frames without id', () => {
+    render(
+      getComponent({
+        data: [
+          {
+            fields: dataFrameA.fields,
+            length: dataFrameA.length,
+          },
+          {
+            fields: dataFrameB.fields,
+            length: dataFrameB.length,
+          },
+        ],
+        items: [],
+      })
+    );
+
+    expect(Select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          {
+            value: '0:field1',
+            source: 0,
+            fieldName: 'field1',
+            label: '0:field1',
+          },
+          {
+            value: '0:field2',
+            source: 0,
+            fieldName: 'field2',
+            label: '0:field2',
+          },
+          {
+            value: '1:fieldB1',
+            source: 1,
+            fieldName: 'fieldB1',
+            label: '1:fieldB1',
+          },
+          {
+            value: '1:fieldB2',
+            source: 1,
+            fieldName: 'fieldB2',
+            label: '1:fieldB2',
+          },
+        ],
+      }),
+      expect.anything()
+    );
+  });
+
   it('Should allow select fields only from the current data frame', () => {
     render(
       getComponent({
@@ -171,6 +225,43 @@ describe('LevelsEditor', () => {
           {
             value: 'field2',
             source: 'A',
+            fieldName: 'field2',
+            label: 'field2',
+          },
+        ],
+      }),
+      expect.anything()
+    );
+  });
+
+  it('Should allow select fields only from the current data frame without id', () => {
+    render(
+      getComponent({
+        data: [
+          {
+            fields: dataFrameA.fields,
+            length: dataFrameA.length,
+          },
+          {
+            fields: dataFrameB.fields,
+            length: dataFrameB.length,
+          },
+        ],
+        items: [
+          {
+            name: 'field1',
+            source: 0,
+          },
+        ],
+      })
+    );
+
+    expect(Select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          {
+            value: 'field2',
+            source: 0,
             fieldName: 'field2',
             label: 'field2',
           },

--- a/src/components/LevelsEditor/LevelsEditor.tsx
+++ b/src/components/LevelsEditor/LevelsEditor.tsx
@@ -108,7 +108,7 @@ export const LevelsEditor: React.FC<Props> = ({ items: groupLevels, name, onChan
 
       if (dataFrame) {
         return (
-          dataFrame?.fields
+          dataFrame.fields
             .map(({ name }) => ({
               label: name,
               source: dataFrame.refId ?? dataFrameIndex,

--- a/src/components/LevelsEditor/LevelsEditor.tsx
+++ b/src/components/LevelsEditor/LevelsEditor.tsx
@@ -101,28 +101,37 @@ export const LevelsEditor: React.FC<Props> = ({ items: groupLevels, name, onChan
     const nameField = items[items.length - 1];
 
     if (nameField) {
-      const dataFrame = data.find((dataFrame) => dataFrame.refId === nameField?.source);
-
-      return (
-        dataFrame?.fields
-          .map(({ name }) => ({
-            label: name,
-            source: dataFrame.refId,
-            value: name,
-            fieldName: name,
-          }))
-          .filter((option) => !items.some((item) => item.name === option.value)) || []
+      const dataFrameIndex = data.findIndex((dataFrame, index) =>
+        dataFrame.refId === undefined ? index === nameField.source : dataFrame.refId === nameField.source
       );
+      const dataFrame = data[dataFrameIndex];
+
+      if (dataFrame) {
+        return (
+          dataFrame?.fields
+            .map(({ name }) => ({
+              label: name,
+              source: dataFrame.refId ?? dataFrameIndex,
+              value: name,
+              fieldName: name,
+            }))
+            .filter((option) => !items.some((item) => item.name === option.value)) || []
+        );
+      }
     }
 
-    return data.reduce((acc: SelectableValue[], dataFrame) => {
+    return data.reduce((acc: SelectableValue[], dataFrame, index) => {
       return acc.concat(
-        dataFrame.fields.map((field) => ({
-          value: `${dataFrame.refId}:${field.name}`,
-          fieldName: field.name,
-          label: `${dataFrame.refId}:${field.name}`,
-          source: dataFrame.refId,
-        }))
+        dataFrame.fields.map((field) => {
+          const source = dataFrame.refId || index;
+
+          return {
+            value: `${source}:${field.name}`,
+            fieldName: field.name,
+            label: `${source}:${field.name}`,
+            source,
+          };
+        })
       );
     }, []);
   }, [data, items]);

--- a/src/types/panel.ts
+++ b/src/types/panel.ts
@@ -19,9 +19,9 @@ export interface Level {
   name: string;
 
   /**
-   * Data Frame Id
+   * Data Frame ID or Frame Index if no specified
    */
-  source: string;
+  source: string | number;
 }
 
 /**

--- a/src/utils/table.test.ts
+++ b/src/utils/table.test.ts
@@ -227,6 +227,32 @@ describe('Table Utils', () => {
       ]);
     });
 
+    it('Should find correct dataFrame by index ', () => {
+      const fields = [{ name: 'country', source: 0 }];
+      const frameA = toDataFrame({
+        fields: [
+          {
+            name: 'country',
+            values: ['USA', 'Japan'],
+          },
+        ],
+      });
+      const result = getRows({ series: [frameA] } as any, fields, getItem);
+
+      expect(result).toEqual([
+        {
+          value: 'USA',
+          label: 'USA',
+          ...defaultItem,
+        },
+        {
+          value: 'Japan',
+          label: 'Japan',
+          ...defaultItem,
+        },
+      ]);
+    });
+
     it('Should filter groups with unselectable child values', () => {
       const fields = [
         { name: 'country', source: 'a' },

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -114,7 +114,9 @@ export const getRows = (
   getItem?: (item: object, key: string, children?: TableItem[]) => TableItem
 ): TableItem[] | null => {
   const lastLevel = levels[levels.length - 1];
-  const dataFrame = data.series.find((dataFrame) => dataFrame.refId === lastLevel.source);
+  const dataFrame = data.series.find((dataFrame, index) =>
+    dataFrame.refId === undefined ? index === lastLevel.source : dataFrame.refId === lastLevel.source
+  );
 
   if (!dataFrame) {
     return null;


### PR DESCRIPTION
Resolves #80 

Using dataFrame index if no refId
<img width="549" alt="Screenshot 2023-11-07 at 10 59 57" src="https://github.com/VolkovLabs/volkovlabs-variable-panel/assets/15867703/1cf65804-1e8f-4b5a-82a5-a589a932e47c">
