### PR TITLE
Add clean table state on tab change

### DIFF
--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -161,6 +161,7 @@ export const TableView: React.FC<Props> = ({ data, options, width, height, event
             </div>
           )}
           <Table
+            key={currentGroup}
             columns={columns}
             data={tableData}
             getSubRows={getSubRows}


### PR DESCRIPTION
Resolves #94 

Due to performance reason we can't keep independent state for each tab so just clean tab state on change